### PR TITLE
Remove learnupon API calls, add filtering for users, export all courses by default

### DIFF
--- a/learnupon_exporter/__init__.py
+++ b/learnupon_exporter/__init__.py
@@ -4,6 +4,6 @@ Django plugin application for exporting edX data to LearnUpon
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 default_app_config = 'learnupon_exporter.apps.LearnUponExporterAppConfig'  # pylint: disable=invalid-name

--- a/learnupon_exporter/__init__.py
+++ b/learnupon_exporter/__init__.py
@@ -4,6 +4,6 @@ Django plugin application for exporting edX data to LearnUpon
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 default_app_config = 'learnupon_exporter.apps.LearnUponExporterAppConfig'  # pylint: disable=invalid-name

--- a/learnupon_exporter/apps.py
+++ b/learnupon_exporter/apps.py
@@ -22,11 +22,9 @@ class LearnUponExporterAppConfig(AppConfig):
         PluginSettings.CONFIG: {
             ProjectType.LMS: {
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: 'settings'},
-                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
             },
             ProjectType.CMS: {
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: 'settings'},
-                SettingsType.PRODUCTION: {PluginSettings.RELATIVE_PATH: 'settings'},
             },
         },
     }

--- a/learnupon_exporter/management/commands/__init__.py
+++ b/learnupon_exporter/management/commands/__init__.py
@@ -41,7 +41,7 @@ class ExportCommand(BaseCommand):  # pylint: disable=abstract-method
         )
 
         self.args["course_ids"] = parser.add_argument(
-            "course_ids", type=str, help="List of Course Ids to export.", nargs="+"
+            "course_ids", type=str, help="List of Course Ids to export.", nargs="*"
         )
 
         self.options["start_date"] = parser.add_argument(

--- a/learnupon_exporter/management/commands/__init__.py
+++ b/learnupon_exporter/management/commands/__init__.py
@@ -11,32 +11,31 @@ from common.djangoapps.student.models import CourseEnrollment
 
 
 def dir_path(string):
-    """ Check that an argument is a valid directory """
+    """Check that an argument is a valid directory"""
     if os.path.isdir(string):
         return string
     else:
         raise ValueError("{string} is not a directory")
 
-class ExportCommand(BaseCommand): # pylint: disable=abstract-method
+
+class ExportCommand(BaseCommand):  # pylint: disable=abstract-method
     """
     Base command for export classes.
     """
+
     def add_arguments(self, parser):
         """
         Add named arguments.
         """
-        self.args['output_dir'] = parser.add_argument(
-            'output_dir',
+        self.args["output_dir"] = parser.add_argument(
+            "output_dir",
             type=dir_path,
-            default='/edx/src/learnupon-exporter/out',
-            help='Directory to put the LearnUpon output files',
+            default="/edx/src/learnupon-exporter/out",
+            help="Directory to put the LearnUpon output files",
         )
 
-        self.args['course_ids'] = parser.add_argument(
-            'course_ids',
-            type=str,
-            help='List of Course Ids to export',
-            nargs='+'
+        self.args["course_ids"] = parser.add_argument(
+            "course_ids", type=str, help="List of Course Ids to export", nargs="+"
         )
 
     def __init__(self, *args, **kwargs):
@@ -47,15 +46,16 @@ class ExportCommand(BaseCommand): # pylint: disable=abstract-method
         self.args = {}
         self.course_ids = []
         self.enrollments = CourseEnrollment.objects.none()
+        self.grades = {}
 
     def set_logging(self, verbosity):
         """
         Set the logging level depending on the desired vebosity
         """
         handler = logging.StreamHandler()
-        root_logger = logging.getLogger('')
+        root_logger = logging.getLogger("")
         root_logger.addHandler(handler)
-        handler.setFormatter(logging.Formatter('%(levelname)s|%(message)s'))
+        handler.setFormatter(logging.Formatter("%(levelname)s|%(message)s"))
 
         if verbosity == 1:
             self.logger.setLevel(logging.WARNING)
@@ -63,7 +63,9 @@ class ExportCommand(BaseCommand): # pylint: disable=abstract-method
             self.logger.setLevel(logging.INFO)
         elif verbosity == 3:
             self.logger.setLevel(logging.DEBUG)
-            handler.setFormatter(logging.Formatter('%(name)s|%(asctime)s|%(levelname)s|%(message)s'))
+            handler.setFormatter(
+                logging.Formatter("%(name)s|%(asctime)s|%(levelname)s|%(message)s")
+            )
 
     def get_s3_bucket(self):
         """
@@ -78,7 +80,7 @@ class ExportCommand(BaseCommand): # pylint: disable=abstract-method
             aws_access_key_id=settings.LEARNUPON_EXPORTER_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=settings.LEARNUPON_EXPORTER_AWS_ACCESS_KEY_SECRET,
         )
-        s3 = session.resource('s3')
+        s3 = session.resource("s3")
         return s3.Bucket(settings.LEARNUPON_EXPORTER_STATIC_FILES_BUCKET)
 
     def upload_file_to_s3(self, s3_bucket, file_object, filename):
@@ -96,4 +98,4 @@ class ExportCommand(BaseCommand): # pylint: disable=abstract-method
 
         if not date:
             return date
-        return date.strftime('%d/%m/%Y')
+        return date.strftime("%d/%m/%Y")

--- a/learnupon_exporter/management/commands/learnupon_export_enrollment_data.py
+++ b/learnupon_exporter/management/commands/learnupon_export_enrollment_data.py
@@ -12,8 +12,6 @@ from django.utils import timezone
 
 from common.djangoapps.student.models import CourseEnrollment
 from lms.djangoapps.grades.models import PersistentCourseGrade
-from edxlearndot.learndot import LearndotAPIClient
-from edxlearndot.models import CourseMapping, EnrolmentStatusLog
 
 from . import ExportCommand
 
@@ -22,81 +20,34 @@ class Command(ExportCommand):
     """
     export_enrollment_data management command.
     """
+
     def handle(self, *args, **options):
         """
         Create the export
         """
-        self.set_logging(options['verbosity'])
+        self.set_logging(options["verbosity"])
 
         now = timezone.now()
         filename = f"enrollment_export{now:%Y%m%d_%H%M%S}.csv"
-        filepath = os.path.join(options['output_dir'], filename)
+        filepath = os.path.join(options["output_dir"], filename)
 
-        self.course_ids = options['course_ids']
-        self.logger.info("Exporting courses: %s", ', '.join(self.course_ids))
+        self.course_ids = options["course_ids"]
+        self.logger.info("Exporting courses: %s", ", ".join(self.course_ids))
         self.enrollments = CourseEnrollment.objects.filter(course__in=self.course_ids)
+        self.stdout.write("Fetching grades...")
+        self.grades = {
+            (grade.user_id, grade.course_id): grade
+            for grade in PersistentCourseGrade.objects.all()
+        }
 
-        with open(filepath, 'w', encoding='utf8') as csv_file:
+        with open(filepath, "w", encoding="utf8") as csv_file:
             self.export_enrollment_data(csv_file)
 
         s3_bucket = self.get_s3_bucket()
 
         if s3_bucket is not None:
-            with open(filepath, 'rb') as csv_file:
+            with open(filepath, "rb") as csv_file:
                 self.upload_file_to_s3(s3_bucket, csv_file, filename)
-
-    def get_enrollment_ids_for_user(self, user, course_mappings):
-        """
-        Fetch the learndot enrollment ids for the provided user.
-
-        Returns:
-        - Dictionary with
-           - key=learndot enrollment id
-           - value=the relevant CourseEnrollment instance
-        """
-        self.logger.debug("Fetching enrollment ids for user: %s", user)
-        enrollments = self.enrollments.filter(user=user).select_related('user')
-        learndot_client = LearndotAPIClient()
-        enrollment_ids = {}
-        contact_id = learndot_client.get_contact_id(user)
-
-        for enrollment in enrollments:
-            course_key = str(enrollment.course_id)
-            if course_key in course_mappings and contact_id:
-                course_mapping = course_mappings[course_key]
-                enrollment_id = learndot_client.get_enrolment_id(contact_id, course_mapping.learndot_component_id)
-                enrollment_ids[enrollment] = enrollment_id
-            else:
-                enrollment_ids[enrollment] = None
-
-        self.logger.info("Fetched enrollment ids for user: %s", user)
-        return enrollment_ids
-
-    def fetch_learndot_enrollments(self):
-        """
-        Fetch learndot enrollment ids for all users in the system.
-
-        Returns:
-        - Dictionary with
-           - key=learndot enrollment id
-           - value=the relevant CourseEnrollment instance
-        """
-
-        course_mappings = {str(m.edx_course_key): m for m in CourseMapping.objects.all()}
-
-        user_ids = self.enrollments.filter(course__in=self.course_ids).values('user_id')
-        users = get_user_model().objects.filter(pk__in=user_ids)
-
-        user_count = users.count()
-        ten_percent = int(user_count / 10)
-
-        self.logger.info("Fetching learndot enrollments for %s users", user_count)
-        
-        for index, user in enumerate(users):
-            if index % ten_percent == 0:
-                self.logger.info('Fetching %s of %s', index + 1, user_count)
-            user_enrollment_ids = self.get_enrollment_ids_for_user(user, course_mappings)
-            yield from user_enrollment_ids.items()
 
     def export_enrollment_data(self, csv_file):
         """
@@ -104,35 +55,51 @@ class Command(ExportCommand):
         """
         field_mapping = {
             "Login ID": "user.email",
-            "Course Name": "course_id",
-            "Enrollment Status": "",
-            "Enrollment Completed Date": "",
-            "Enrollment Created Date": "",
+            "Course Name": "course.display_name",
+            "Enrollment Created Date": "created",
             "Enrollment Started Date": "",
+            "Enrollment Completed Date": "",
             "Enrollment Score": "",
-            "Enrollment Access Expires Date": ""
+            "Enrollment Status": "",
+            "Enrollment Access Expires Date": "course.end",
         }
 
         writer = csv.DictWriter(csv_file, fieldnames=field_mapping)
 
         writer.writeheader()
-        enrollment_statuses = {es.learndot_enrolment_id: es for es in EnrolmentStatusLog.objects.all()}
+        enrollments = self.enrollments
 
-        for enrollment, enrollment_id in self.fetch_learndot_enrollments():
+        record_count = self.enrollments.count()
+        self.stdout.write(f"Writing {record_count} enrollments")
+        batch_size = int(record_count / 10) or 1
+
+        for record_index, enrollment in enumerate(enrollments):
+            if record_index > 0 and record_index % batch_size == 0:
+                self.stdout.write(f"Completed: {record_index + 1} of {record_count}")
+
             pseudo_context = {"obj": enrollment}
             row = {}
             for csv_field, instance_field in field_mapping.items():
                 if not instance_field:
-                    row[csv_field] = ""
-                else:
-                    row[csv_field] = Variable(f"obj.{instance_field}").resolve(pseudo_context)
+                    continue
+                row[csv_field] = Variable(f"obj.{instance_field}").resolve(
+                    pseudo_context
+                )
 
-            row['Enrollment Status'] = 'not started'
-            enrollment_status = enrollment_statuses.get(enrollment_id)
-            if enrollment_status:
-                grade = enrollment_status.status.lower()
-                if grade == 'passed':
-                    row['Enrollment Status'] = 'passed'
-                    row['Enrollment Completed Date'] = self.format_date(enrollment_status.updated_at)
+            row["Enrollment Status"] = "not started"
+            grade = self.grades.get((enrollment.user_id, enrollment.course_id))
+            modules = enrollment.user.studentmodule_set.filter(
+                course_id=enrollment.course_id
+            ).order_by("created")
+            first_block_viewed_at = modules.values_list("created", flat=True).first()
 
+            if first_block_viewed_at:
+                row["Enrollment Status"] = "started"
+                row["Enrollment Started Date"] = first_block_viewed_at
+
+            if grade:
+                row["Enrollment Score"] = grade.percent_grade
+                row["Enrollment Completed Date"] = grade.created
+                row["Enrollment Status"] = "completed"
             writer.writerow(row)
+        self.stdout.write("Done!")

--- a/learnupon_exporter/management/commands/learnupon_export_enrollment_data.py
+++ b/learnupon_exporter/management/commands/learnupon_export_enrollment_data.py
@@ -29,12 +29,13 @@ class Command(ExportCommand):
         Create the export
         """
         self.set_logging(options["verbosity"])
+        self.course_ids = options["course_ids"]
 
         now = timezone.now()
-        filename = f"enrollment_export{now:%Y%m%d_%H%M%S}.csv"
+        filename = f"enrollment_export{now:%Y%m%d_%H%M%S}_{'_'.join(self.course_ids)}.csv"
         filepath = os.path.join(options["output_dir"], filename)
 
-        self.course_ids = options["course_ids"]
+        
         self.logger.info("Exporting courses: %s", ", ".join(self.course_ids))
         self.enrollments = CourseEnrollment.objects.filter(course__in=self.course_ids)
 

--- a/learnupon_exporter/management/commands/learnupon_export_enrollment_data.py
+++ b/learnupon_exporter/management/commands/learnupon_export_enrollment_data.py
@@ -113,9 +113,9 @@ class Command(ExportCommand):
                 row["Enrollment Status"] = "completed"
                 row["Enrollment Started Date"] = first_block_viewed_at
 
-            if grade:
+            if grade and grade.passed_timestamp:
                 row["Enrollment Score"] = grade.percent_grade
-                row["Enrollment Completed Date"] = grade.created
+                row["Enrollment Completed Date"] = grade.passed_timestamp
                 row["Enrollment Status"] = "completed"
             writer.writerow(row)
         self.stdout.write("Done!")


### PR DESCRIPTION
## Description

- Adds date and email filters
- Removes the learnupon API calls and populate data from edX tables
- Exports all courses if none are provided

## Testing instructions

Run the exports as normal. The data should be populated from edx tables so should go a lot faster.

## Testing instructions

 Install the code with the command `pip install git+https://github.com/open-craft/learnupon-exporter.git@keith/openedx-tables`

The base command to run an export is: `python manage.py lms learnupon_export_enrollment_data /edx/src/export "course-v1:edX+DemoX+Demo_Course"`

- To export users based on the email domain you can add the option `--email-domain=example.com` and all the records will contain only users with email addresses that belong to that domain.
- To filter on start date, add the option `--start-date=2020-01-01` (`YYYY-MM-DD` format) and records will be filtered for users that started the course after the provided date.
